### PR TITLE
feat: add hybrid translation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # English - Greenlandic Translator
 
-This is a simple translator that translates English to Greenlandic and Greenlandic to English. It pulls directly from [Nutserut](https://nutserut.gl/en), a service from [The Language Secretariat of Greenland](https://oqaasileriffik.gl/en/). Using Danish as a proxy language, it then pulls from the [Google Translate API](https://cloud.google.com/translate/docs/) to deliver an English translation, and vice versa.
+This is a simple translator that translates English to Greenlandic and Greenlandic to English. It pulls directly from [Nutserut](https://nutserut.gl/en), a service from [The Language Secretariat of Greenland](https://oqaasileriffik.gl/en/). Using Danish as a proxy language, it then pulls from the [Google Translate API](https://cloud.google.com/translate/docs/) to deliver an English translation, and vice versa. The application now targets Nutserut's **hybrid** endpoint while preserving the legacy method internally for future toggling. The intermediate Danish text and step-by-step status messages are surfaced in the UI to show each stage of the translation process.
 
 To distribute this service widely, consultation would be needed with the Language Secretariat of Greenland to ensure that their server is not abused. This is a proof of concept, and is not intended to be used in production.
 
@@ -8,6 +8,7 @@ To distribute this service widely, consultation would be needed with the Languag
 
 - The app calls the public `translate.googleapis.com` endpoint from the browser; no API key is used. Reliability and rate limits may vary.
 - Danish is used as a pivot language between Greenlandic and English.
+- Nutserut's hybrid endpoint is used for Greenlandic-Danish conversion; the classic endpoint remains available in the code for experimentation.
 - No server-side persistence; requests are issued directly from the client. Be mindful of CORS and upstream availability.
 
 ## Developing

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,10 +4,12 @@
 	import socialImage from '$lib/images/social.jpg';
 
 	let english = '';
+	let danish = '';
 	let greenlandic = '';
 
 	let fromEnglish = true;
 	let loading = false;
+	let status = '';
 
 	function switchLanguage() {
 		// Clear the input field
@@ -16,6 +18,7 @@
 		} else if (!fromEnglish) {
 			greenlandic = '';
 		}
+		danish = '';
 		fromEnglish = !fromEnglish;
 	}
 
@@ -31,16 +34,21 @@
 	 */
 	async function translate(text) {
 		loading = true;
+		danish = '';
+		status = fromEnglish ? 'Translating English to Danish…' : 'Translating Greenlandic to Danish…';
 		try {
 			if (fromEnglish) {
-				const danish = await translateDanish(text);
+				danish = await translateDanish(text);
+				status = 'Translating Danish to Greenlandic…';
 				greenlandic = await translateGreenlandicHybrid(danish, 'dan2kal');
 			} else {
-				const danish = await translateGreenlandicHybrid(text, 'kal2dan');
+				danish = await translateGreenlandicHybrid(text, 'kal2dan');
+				status = 'Translating Danish to English…';
 				english = await translateDanish(danish);
 			}
 		} finally {
 			loading = false;
+			status = '';
 		}
 	}
 
@@ -151,8 +159,19 @@
 			</button>
 			<button class="subtle" on:click={switchLanguage} disabled={loading}>Switch Language</button>
 			{#if loading}
-				<span class="loading">Translating…</span>
+				<span class="loading">{status}</span>
 			{/if}
+		</div>
+		<div id="danish">
+			<label for="danish-output">dansk (Danish)</label>
+			<textarea
+				bind:value={danish}
+				disabled
+				id="danish-output"
+				name="Danish"
+				rows="5"
+				spellcheck="false"
+			/>
 		</div>
 		<div id="english">
 			<label for="english-input">English</label>
@@ -164,7 +183,7 @@
 				rows="5"
 			/>
 		</div>
-		<button on:click={() => copy(fromEnglish ? greenlandic : english)}
+		<button id="copy" on:click={() => copy(fromEnglish ? greenlandic : english)}
 			>Copy Result to Clipboard</button
 		>
 	</section>
@@ -197,10 +216,11 @@
 	section {
 		display: grid;
 		grid-template-columns: 1fr;
-		grid-template-rows: 1fr auto 1fr;
+		grid-template-rows: 1fr auto 1fr 1fr auto;
 		grid-template-areas:
 			'input'
 			'controls'
+			'danish'
 			'result'
 			'copy';
 	}
@@ -214,8 +234,14 @@
 	#greenlandic {
 		grid-area: var(--greenlandic);
 	}
+	#danish {
+		grid-area: danish;
+	}
 	#english {
 		grid-area: var(--english);
+	}
+	#copy {
+		grid-area: copy;
 	}
 	button.subtle {
 		background-color: var(--text);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
 	let greenlandic = '';
 
 	let fromEnglish = true;
+	let loading = false;
 
 	function switchLanguage() {
 		// Clear the input field
@@ -28,15 +29,18 @@
 	/**
 	 * @param {string} text
 	 */
-	function translate(text) {
-		if (fromEnglish) {
-			translateDanish(text).then((r) =>
-				translateGreenlandicHybrid(r, 'dan2kal').then((r) => (greenlandic = r))
-			);
-		} else {
-			translateGreenlandicHybrid(text, 'kal2dan').then((r) =>
-				translateDanish(r).then((r) => (english = r))
-			);
+	async function translate(text) {
+		loading = true;
+		try {
+			if (fromEnglish) {
+				const danish = await translateDanish(text);
+				greenlandic = await translateGreenlandicHybrid(danish, 'dan2kal');
+			} else {
+				const danish = await translateGreenlandicHybrid(text, 'kal2dan');
+				english = await translateDanish(danish);
+			}
+		} finally {
+			loading = false;
 		}
 	}
 
@@ -142,8 +146,13 @@
 			/>
 		</div>
 		<div id="controls">
-			<button on:click={() => translate(fromEnglish ? english : greenlandic)}>Translate</button>
-			<button class="subtle" on:click={switchLanguage}>Switch Language</button>
+			<button on:click={() => translate(fromEnglish ? english : greenlandic)} disabled={loading}>
+				Translate
+			</button>
+			<button class="subtle" on:click={switchLanguage} disabled={loading}>Switch Language</button>
+			{#if loading}
+				<span class="loading">Translating…</span>
+			{/if}
 		</div>
 		<div id="english">
 			<label for="english-input">English</label>
@@ -212,5 +221,8 @@
 		background-color: var(--text);
 		color: var(--bg);
 		opacity: 0.9;
+	}
+	.loading {
+		margin-left: 1em;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,8 @@
 
 	let fromEnglish = true;
 	let loading = false;
-	let status = '';
+	/** @type {string[]} */
+	let progress = [];
 
 	function switchLanguage() {
 		// Clear the input field
@@ -35,20 +36,25 @@
 	async function translate(text) {
 		loading = true;
 		danish = '';
-		status = fromEnglish ? 'Translating English to Danish…' : 'Translating Greenlandic to Danish…';
+		progress = [
+			fromEnglish ? '1/2 Translating English to Danish…' : '1/2 Translating Greenlandic to Danish…'
+		];
 		try {
 			if (fromEnglish) {
 				danish = await translateDanish(text);
-				status = 'Translating Danish to Greenlandic…';
+				progress[0] = '1/2 English to Danish ✓';
+				progress.push('2/2 Translating Danish to Greenlandic…');
 				greenlandic = await translateGreenlandicHybrid(danish, 'dan2kal');
+				progress[1] = '2/2 Danish to Greenlandic ✓';
 			} else {
 				danish = await translateGreenlandicHybrid(text, 'kal2dan');
-				status = 'Translating Danish to English…';
+				progress[0] = '1/2 Greenlandic to Danish ✓';
+				progress.push('2/2 Translating Danish to English…');
 				english = await translateDanish(danish);
+				progress[1] = '2/2 Danish to English ✓';
 			}
 		} finally {
 			loading = false;
-			status = '';
 		}
 	}
 
@@ -131,7 +137,9 @@
 	>
 	<h1>Greenlandic - English Translator</h1>
 	<p>
-		Begin by entering words and simple phrases, then press the <strong>Translate</strong> button.
+		Begin by entering words and simple phrases, then press the <strong>Translate</strong> button. The
+		translation moves through Danish as an intermediary; the Danish result and step‑by‑step status messages
+		will appear below while the request is processed.
 	</p>
 </header>
 
@@ -158,8 +166,12 @@
 				Translate
 			</button>
 			<button class="subtle" on:click={switchLanguage} disabled={loading}>Switch Language</button>
-			{#if loading}
-				<span class="loading">{status}</span>
+			{#if progress.length}
+				<ul class="loading">
+					{#each progress as step}
+						<li>{step}</li>
+					{/each}
+				</ul>
 			{/if}
 		</div>
 		<div id="danish">
@@ -191,10 +203,10 @@
 		This tool works by calling on two services: <a href="https://nutserut.gl/en" target="_blank"
 			>Nutserut</a
 		>
-		(Greenlandic - Danish) and
+		(Greenlandic - Danish via its hybrid endpoint) and
 		<a href="https://translate.google.ca/?sl=da&tl=en&op=translate" target="_blank"
 			>Google Translate</a
-		> (Danish - English). By using Danish as a proxy language, an approximate translation can be provided.
+		> (Danish - English). The Danish intermediary text and status list above show each stage for transparency.
 		This is experimental and may break if the external services change. It currently works best with
 		words and simple phrases, as the underlying translation service is still being developed. Specifically,
 		this tool translates between English and West Greenlandic (kalaallisut, the official language of
@@ -250,5 +262,7 @@
 	}
 	.loading {
 		margin-left: 1em;
+		list-style: none;
+		padding-left: 1em;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,31 +30,41 @@
 	 */
 	function translate(text) {
 		if (fromEnglish) {
-			translateDanish(text).then((r) => translateGreenlandic(r).then((r) => (greenlandic = r)));
-		} else if (!fromEnglish) {
-			translateGreenlandic(text).then((r) => translateDanish(r).then((r) => (english = r)));
+			translateDanish(text).then((r) =>
+				translateGreenlandicClassic(r, 'dan2kal').then((r) => (greenlandic = r))
+			);
+		} else {
+			translateGreenlandicHybrid(text).then((r) => translateDanish(r).then((r) => (english = r)));
 		}
 	}
 
 	/**
+	 * Legacy Nutserut translation.
 	 * @param {string} text
+	 * @param {'kal2dan' | 'dan2kal'} direction
 	 */
-	function translateGreenlandic(text) {
-		return fetch(
-			`https://nutserut.gl/callback.php?a=${fromEnglish ? 'dan2kal' : 'kal2qdx'}&t=${encodeURI(
-				text
-			)}`
-		)
+	function translateGreenlandicClassic(text, direction) {
+		const action = direction === 'dan2kal' ? 'dan2kal' : 'kal2qdx';
+		return fetch(`https://nutserut.gl/callback.php?a=${action}&t=${encodeURIComponent(text)}`)
 			.then((r) => r.json())
 			.then((t) => {
-				if (fromEnglish) {
-					let withoutBreaks = t?.output.replace(/\n\n\n\n\n/gm, '');
-					console.log({ t, minimizeBreaks: withoutBreaks });
+				if (direction === 'dan2kal') {
+					let withoutBreaks = t?.output?.replace(/\n\n\n\n\n/gm, '');
 					return withoutBreaks;
-				} else if (!fromEnglish) {
-					return t?.moved;
+				} else {
+					return t?.moved ?? t?.output;
 				}
 			});
+	}
+
+	/**
+	 * Hybrid Nutserut translation (Greenlandic to Danish).
+	 * @param {string} text
+	 */
+	function translateGreenlandicHybrid(text) {
+		return fetch(`https://nutserut.gl/callback.php?a=h-kal2dan&t=${encodeURIComponent(text)}`)
+			.then((r) => r.json())
+			.then((t) => t?.output);
 	}
 
 	/**

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,10 +31,12 @@
 	function translate(text) {
 		if (fromEnglish) {
 			translateDanish(text).then((r) =>
-				translateGreenlandicClassic(r, 'dan2kal').then((r) => (greenlandic = r))
+				translateGreenlandicHybrid(r, 'dan2kal').then((r) => (greenlandic = r))
 			);
 		} else {
-			translateGreenlandicHybrid(text).then((r) => translateDanish(r).then((r) => (english = r)));
+			translateGreenlandicHybrid(text, 'kal2dan').then((r) =>
+				translateDanish(r).then((r) => (english = r))
+			);
 		}
 	}
 
@@ -43,6 +45,7 @@
 	 * @param {string} text
 	 * @param {'kal2dan' | 'dan2kal'} direction
 	 */
+	// eslint-disable-next-line no-unused-vars
 	function translateGreenlandicClassic(text, direction) {
 		const action = direction === 'dan2kal' ? 'dan2kal' : 'kal2qdx';
 		return fetch(`https://nutserut.gl/callback.php?a=${action}&t=${encodeURIComponent(text)}`)
@@ -58,11 +61,13 @@
 	}
 
 	/**
-	 * Hybrid Nutserut translation (Greenlandic to Danish).
+	 * Hybrid Nutserut translation.
 	 * @param {string} text
+	 * @param {'kal2dan' | 'dan2kal'} direction
 	 */
-	function translateGreenlandicHybrid(text) {
-		return fetch(`https://nutserut.gl/callback.php?a=h-kal2dan&t=${encodeURIComponent(text)}`)
+	function translateGreenlandicHybrid(text, direction) {
+		const action = direction === 'dan2kal' ? 'm-dan2kal' : 'h-kal2dan';
+		return fetch(`https://nutserut.gl/callback.php?a=${action}&t=${encodeURIComponent(text)}`)
 			.then((r) => r.json())
 			.then((t) => t?.output);
 	}

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,19 +1,19 @@
 {
-    "name": "Greenlandic Translator",
-    "short_name": "Greenlandic",
-    "icons": [
-        {
-            "src": "/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ],
-    "theme_color": "#006a90",
-    "background_color": "#006a90",
-    "display": "standalone"
+	"name": "Greenlandic Translator",
+	"short_name": "Greenlandic",
+	"icons": [
+		{
+			"src": "/android-chrome-192x192.png",
+			"sizes": "192x192",
+			"type": "image/png"
+		},
+		{
+			"src": "/android-chrome-512x512.png",
+			"sizes": "512x512",
+			"type": "image/png"
+		}
+	],
+	"theme_color": "#006a90",
+	"background_color": "#006a90",
+	"display": "standalone"
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
-	expect(await page.textContent('h1')).toBe('Welcome to SvelteKit');
+	expect(await page.textContent('h1')).toBe('Greenlandic - English Translator');
 });


### PR DESCRIPTION
## Summary
- support Nutserut's hybrid Greenlandic→Danish endpoint
- keep legacy Nutserut calls to allow future toggling
- update Playwright test to match current landing page

## Testing
- `npm run lint`
- `curl -m 10 -X POST -d 'a=h-kal2dan&t=aluu' https://nutserut.gl/callback.php`
- `curl -s http://localhost:5174 | head -n 5`
- `npx playwright install chromium` *(fails: Error: Socket is closed)*

------
https://chatgpt.com/codex/tasks/task_b_68af3e9b7b2c8322869e807e6b62f82c